### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Base OS
+FROM ubuntu:20.04
+# Container Metadata
+LABEL maintainer="20195932+wrongkindofdoctor@users.noreply.github.com"
+LABEL version="alpha-01"
+LABEL description="This is a docker image for the MDTF-diagnostics package"
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+# Update Ubuntu Software repository
+RUN apt update
+# Install dependencies
+RUN apt install -y wget
+RUN apt install -y vim
+# Cleanup
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt clean
+# Install Miniconda3
+# Download the latest shell script
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+# Change permission to execute build script
+RUN chmod +x Miniconda3-latest-Linux-x86_64.sh
+# Run miniconda installation script
+ENV PATH="/root/miniconda3/bin:${PATH}"
+ARG PATH="/root/miniconda3/bin:${PATH}"
+RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b
+RUN rm -f Miniconda3-latest-Linux-x86_64.sh
+RUN conda info
+RUN conda init bash
+RUN conda install -c conda-forge mamba
+# Copy the MDTF-diagnostics package contents from local machine to image
+ENV CODE_ROOT=/proj/MDTF-diagnostics
+COPY src ${CODE_ROOT}/src
+COPY data ${CODE_ROOT}/data
+#COPY diagnostics ${CODE_ROOT}/diagnostics
+COPY mdtf_framework.py ${CODE_ROOT}
+COPY shared ${CODE_ROOT}/shared
+COPY sites ${CODE_ROOT}/sites
+COPY tests ${CODE_ROOT}/tests
+# Install conda environments
+ENV CONDA_ROOT=/root/miniconda3
+ENV CONDA_ENV_DIR=/root/miniconda3/envs
+RUN bash ${CODE_ROOT}/src/conda/conda_env_setup.sh --all --conda_root ${CONDA_ROOT} \
+    --conda_env_dir ${CONDA_ENV_DIR}
+# Verify installation
+RUN ${CODE_ROOT}/mdtf --version
+# Run mdtf on src/default_tests.jsonc
+CMD ["${CODE_ROOT}/mdtf", "-f","${CODE_ROOT}/src/default_tests.jsonc"]


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.8 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
